### PR TITLE
fix build instructions

### DIFF
--- a/README
+++ b/README
@@ -11,5 +11,5 @@ cbor file.cbor > file.json
 Good to use along with jq.
 Besides converting keys to strings, it doesn't do anything fancy, so it will probably fail if your CBOR has things that don't fit well with JSON it will throw an error.
 
-To compile from source and install, type `go get github.com/fiatjaf/cbor`.
+To compile from source and install, type `go install github.com/fiatjaf/cbor@latest`.
 Or grab a binary from Releases, chmod +x it and put it in your $PATH.


### PR DESCRIPTION
using `go get` to compile is deprecated and no longer works as of go 1.18

https://go.dev/doc/go-get-install-deprecation